### PR TITLE
Fix inferred equivalences

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -79,7 +79,7 @@ release_diff: $(REPORTDIR)/release-diff.md
 
 .PHONY: reason_test
 reason_test: $(EDIT_PREPROCESSED)
-	$(ROBOT) reason --input $< --reasoner ELK --equivalent-classes-allowed all \
+	$(ROBOT) reason --input $< --reasoner ELK --equivalent-classes-allowed asserted-only \
 		--exclude-tautologies structural --output test.owl && rm test.owl
 
 .PHONY: odkversion
@@ -445,7 +445,7 @@ $(ONT)-base.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned.
 $(ONT)-full.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
 	$(ROBOT_RELEASE_IMPORT_MODE) \
-		reason --reasoner ELK --equivalent-classes-allowed all --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		$(SHARED_ROBOT_COMMANDS) annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@

--- a/src/ontology/uo-edit.owl
+++ b/src/ontology/uo-edit.owl
@@ -6165,17 +6165,6 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/UO_0010048">
         <owl:equivalentClass>
             <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_1000013"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/has_prefix"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UO_0000299"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
-        <owl:equivalentClass>
-            <owl:Class>
                 <owl:oneOf rdf:parseType="Collection">
                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010048"/>
                 </owl:oneOf>
@@ -11077,6 +11066,7 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010048">
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">&quot;DEPRECATED: Duplicate of http://purl.obolibrary.org/obo/UO_0000039. A substance unit which is equal to one millionth of a mole.&quot; [UOB:LTS]</rdfs:comment>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">micromole</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010049">
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">g/m^[2]</oboInOwl:hasExactSynonym>

--- a/src/ontology/uo-edit.owl
+++ b/src/ontology/uo-edit.owl
@@ -3064,7 +3064,7 @@
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_1000175"/>
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_1000173"/>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/has_prefix"/>
                         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/UO_0000297"/>

--- a/src/ontology/uo-odk.yaml
+++ b/src/ontology/uo-odk.yaml
@@ -1,5 +1,4 @@
-#allow_equivalents: asserted-only
-allow_equivalents: all
+allow_equivalents: asserted-only
 catalog_file: catalog-v001.xml
 ci:
 - github_actions


### PR DESCRIPTION
This PR implements the fixes proposed in the discussion of #78:

(A) it formally deprecates UO:0010048 and removes its logical definition;

(B) it fixes the bogus logical definition of UO:0000176 to use '[gram per milliliter based unit](http://purl.obolibrary.org/obo/UO_1000173)' as the genus, instead of '[gram per liter based unit](http://purl.obolibrary.org/obo/UO_1000175)'.

Since UO:0000039 == UO:0010048 and UO:0000176 == UO:0000273 were the only two cases of inferred equivalent classes, this PR also updates the ODK configuration to explicitly disallow such equivalences, so that future mistakes like the one in the definition of UO:0000176 can be flagged by the ODK test suite.